### PR TITLE
E1917. Fix Code Climate issues in controllers with names beginning wi…

### DIFF
--- a/app/controllers/survey_deployment_controller.rb
+++ b/app/controllers/survey_deployment_controller.rb
@@ -145,7 +145,7 @@ class SurveyDeploymentController < ApplicationController
     @all_answers = list_answers(@questions, response_map_list)
     @global_survey_present = false
 
-    if sd.global_survey_id
+    unless sd.global_survey_id
       @global_survey_present = true
       @global_questionnaire = Questionnaire.find(sd.global_survey_id)
       @global_questions = Question.where(questionnaire_id: @global_questionnaire.id)


### PR DESCRIPTION
…th P through Z

Resolved unsafe reflection method issues.
Used guard clause to instead of wrapping code in a conditional statement as suggested by codeclimate.